### PR TITLE
build: install eoAPI chart

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## What type of PR is this? (check all applicable)
+
+- [ ] 🍕 Feature
+- [ ] 🐛 Bug Fix
+- [ ] 📝 Documentation
+- [ ] 🧑‍💻 Refactor
+- [ ] ✅ Test
+- [ ] 🤖 Build or CI
+- [ ] ❓ Other (please specify)
+
+## Related Issue
+
+Example: Fixes #123
+
+## Describe this PR
+
+A brief description of how this solves the issue.
+
+## Screenshots
+
+Please provide screenshots of the change.
+
+## Alternative Approaches Considered
+
+Did you attempt any other approaches that are not documented in code?
+
+## Review Guide
+
+Notes for the reviewer. How to test this change?
+
+## Checklist before requesting a review
+
+- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
+- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
+- 👷‍♀️ Create small PRs. In most cases, this will be possible.
+- ✅ Provide tests for your changes.
+- 📝 Use descriptive commit messages.
+- 📗 Update any related documentation and include any relevant screenshots.
+- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.
+
+## [optional] What gif best describes this PR or how it makes you feel?

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,6 @@ jobs:
           validate: true
           format: true
           arg-var-file: ${{ env.VAR_FILE }}
-          label-pr: false
       - name: Get TF Outputs
         run: |
           echo "S3_BACKUP_ROLE=$(tofu -chdir=terraform output -var-file=vars/production.tfvars s3_backup_role)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,6 @@ jobs:
       - name: Deploy eoAPI Chart
         uses: helmfile/helmfile-action@v2.0.4
         with:
-          # helmfile-args: 'apply'
-          helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
+          helmfile-args: 'apply'
+          # helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
           TF_VAR_cluster_ci_access_role_arn: ${{ secrets.AWS_OIDC_ROLE }}
           TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
         with:
-          command: 'apply'
-          # command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+          # command: 'apply'
+          command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
           working-directory: terraform
           validate: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: op5dev/tf-via-pr@v13
         env:
           TF_VAR_cluster_ci_access_role_arn: ${{ secrets.AWS_OIDC_ROLE }}
-          # TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
+          TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
         with:
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,6 @@ jobs:
       - name: Deploy eoAPI Chart
         uses: helmfile/helmfile-action@v2.0.4
         with:
-          helmfile-args: 'apply'
-          # helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
+          # helmfile-args: 'apply'
+          helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,6 @@ jobs:
       - name: Deploy eoAPI Chart
         uses: helmfile/helmfile-action@v2.0.4
         with:
-          helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
+          helmfile-args: 'apply'
+          # helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm
-      - run: |
-          kubectl get clusterissuer -o=jsonpath='{.items[*].spec.acme.email}'
-          kubectl get certificate -n eoapi
-          kubectl get secret/eoapi-tls -n eoapi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,3 @@ jobs:
           helmfile-args: 'apply'
           # helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm
-      - run: |
-          kubectl get certificate -n eoapi
-          kubectl get certificaterequests -n eoapi
-          kubectl get order -n eoapi
-
-          kubectl events --for certificate/eoapi-tls -n eoapi
-          kubectl events --for certificaterequests/eoapi-tls-1 -n eoapi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,17 +33,8 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          list-files: shell
-          filters: |
-            tf: 'terraform/**'
-            manifest:
-              - added|modified: 'kubernetes/manifests/**'
       - name: Provision TF
         uses: op5dev/tf-via-pr@v13
-        if: ${{ steps.changes.outputs.tf == 'true' }}
         with:
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
@@ -60,10 +51,9 @@ jobs:
       - name: Pull kubeconfig
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}
-      - name: Apply changed manifests
-        if: ${{ steps.changes.outputs.manifest == 'true' }}
+      - name: Apply manifests
         run: |
-          kubectl apply -f ${{ steps.filter.outputs.manifest_files }} ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          kubectl apply -f kubernetes/manifests/ ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
       - name: Deploy eoAPI Chart
         uses: helmfile/helmfile-action@v2.0.4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: op5dev/tf-via-pr@v13
         env:
           TF_VAR_cluster_ci_access_role_arn: ${{ secrets.AWS_OIDC_ROLE }}
-          TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
+          # TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
         with:
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
@@ -61,3 +61,7 @@ jobs:
         with:
           helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm
+      - run: |
+          kubectl get clusterissuer -o=jsonpath='{.items[*].spec.acme.email}'
+          kubectl get certificate -n eoapi
+          kubectl get secret/eoapi-tls -n eoapi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
       - name: Provision TF
         uses: op5dev/tf-via-pr@v13
+        env:
+          TF_VAR_cluster_ci_access_role_arn: ${{ secrets.AWS_OIDC_ROLE }}
+          TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
         with:
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
@@ -42,7 +45,6 @@ jobs:
           validate: true
           format: true
           arg-var-file: ${{ env.VAR_FILE }}
-          arg-var: cluster_ci_access_role_arn=${{ secrets.AWS_OIDC_ROLE }}
           label-pr: false
       - name: Get TF Outputs
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,8 @@ jobs:
           TF_VAR_cluster_ci_access_role_arn: ${{ secrets.AWS_OIDC_ROLE }}
           TF_VAR_cluster_admin_access_role_arns: ${{ secrets.CLUSTER_ADMIN_ACCESS_ROLE_ARNS }}
         with:
-          command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+          command: 'apply'
+          # command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
           working-directory: terraform
           validate: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,8 @@ jobs:
           label-pr: false
       - name: Get TF Outputs
         run: |
-          echo "S3_BACKUP_ROLE=$(echo tofu -chdir=terraform output -var-file=vars/production.tfvars s3_backup_role)" >> $GITHUB_ENV
-          echo "CLUSTER_NAME=$(echo tofu -chdir=terraform output -var-file=vars/production.tfvars cluster_name)" >> $GITHUB_ENV
+          echo "S3_BACKUP_ROLE=$(tofu -chdir=terraform output -var-file=vars/production.tfvars s3_backup_role)" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=$(tofu -chdir=terraform output -var-file=vars/production.tfvars cluster_name)" >> $GITHUB_ENV
       - name: Pull kubeconfig
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Deploy Terraform
+name: Deploy Changes
 on:
   push:
     branches:
@@ -33,8 +33,17 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          list-files: shell
+          filters: |
+            tf: 'terraform/**'
+            manifest:
+              - added|modified: 'kubernetes/manifests/**'
       - name: Provision TF
         uses: op5dev/tf-via-pr@v13
+        if: ${{ steps.changes.outputs.tf == 'true' }}
         with:
           command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           tool: tofu
@@ -44,3 +53,19 @@ jobs:
           arg-var-file: ${{ env.VAR_FILE }}
           arg-var: cluster_ci_access_role_arn=${{ secrets.AWS_OIDC_ROLE }}
           label-pr: false
+      - name: Get TF Outputs
+        run: |
+          echo "S3_BACKUP_ROLE=$(echo tofu -chdir=terraform output -var-file=vars/production.tfvars s3_backup_role)" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=$(echo tofu -chdir=terraform output -var-file=vars/production.tfvars cluster_name)" >> $GITHUB_ENV
+      - name: Pull kubeconfig
+        run: |
+          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}
+      - name: Apply changed manifests
+        if: ${{ steps.changes.outputs.manifest == 'true' }}
+        run: |
+          kubectl apply -f ${{ steps.filter.outputs.manifest_files }} ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+      - name: Deploy eoAPI Chart
+        uses: helmfile/helmfile-action@v2.0.4
+        with:
+          helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
+          helmfile-workdirectory: kubernetes/helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,10 @@ jobs:
           helmfile-args: 'apply'
           # helmfile-args: ${{ github.event_name == 'push' && 'apply' || 'diff' }}
           helmfile-workdirectory: kubernetes/helm
+      - run: |
+          kubectl get certificate -n eoapi
+          kubectl get certificaterequests -n eoapi
+          kubectl get order -n eoapi
+
+          kubectl events --for certificate/eoapi-tls -n eoapi
+          kubectl events --for certificaterequests/eoapi-tls-1 -n eoapi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 AWS_PROFILE ?= default
-CLUSTER_NAME = $(shell tofu -chdir=terraform output cluster_name)
-S3_BACKUP_ROLE = $(shell tofu -chdir=terraform output s3_backup_role)
+CLUSTER_NAME = $(shell tofu -chdir=terraform output -var-file=vars/local.tfvars cluster_name)
+S3_BACKUP_ROLE = $(shell tofu -chdir=terraform output -var-file=vars/local.tfvars s3_backup_role)
 
 PGO_CHART_VERSION = 5.7.4
 EOAPI_CHART_VERSION = 0.7.1

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ init-eoapi:
 ## deploy-eoapi: Upgrade or install eoAPI release
 deploy-eoapi:
 	helm repo list | grep "eoapi" >/dev/null 2>&1 || { echo "Not initialized, run 'make init-eoapi' before retrying"; exit 1; }
-	helm upgrade --install --namespace eoapi --create-namespace eoapi eoapi/eoapi --version $(EOAPI_CHART_VERSION) -f kubernetes/helm/eoapi.yaml --set previousVersion=$(EOAPI_CHART_VERSION) --set postgrescluster.metadata.annotations.eks.amazonaws.com/role-arn=$(S3_BACKUP_ROLE)
+	helm upgrade --install --namespace eoapi --create-namespace eoapi eoapi/eoapi --version $(EOAPI_CHART_VERSION) -f kubernetes/helm/eoapi-values.yaml --set previousVersion=$(EOAPI_CHART_VERSION) --set postgrescluster.metadata.annotations."eks\.amazonaws\.com/role-arn"=$(S3_BACKUP_ROLE)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,20 @@ See the [inital proposal](docs/proposal.md) for more background.
 [kubectl](https://kubernetes.io/docs/tasks/tools/)
 [Helm](https://helm.sh/docs/intro/install/)
 
-// TODO 🚧
+
+Areas for Further (Initial) Development:
+
+1. Variable Management
+    1. Duplication exists between TF inputs, CI workflows, and local scripts.
+    1. A tool like https://github.com/helmfile/helmfile may help with sourcing variables by environment.
+        1. A basic version has been added to deploy revision deltas, further templating would be required.
+    1. As more HOT applications + services are moved to cluster, this will only grow.
+1. Deployment
+    1. Provisioning is currently done in the same workflow (TF, K8s, Helm), mostly as byproduct of initial development phase. Can be further refined.
+    1. GitOps tools like ArgoCD are [under consideration](https://github.com/hotosm/k8s-infra/issues/14)
+    1. Flux [Tofu controller](https://github.com/flux-iac/tofu-controller) may be an analog for base infrastructure (further investigation required).
+1. Bridging TF and Kubernetes
+    1. TF-managed information often needs to be referenced on the cluster
+        1. ex: PostgresCluster CRD requires the role ARN authorized for backups. Role and bucket are created in TF.
+    1. Global cluster resources are provisioned through TF, but argument can be made for their management by K8s. 
+    1. Ideal solution enables cluster resources to reference, mount, inject, etc. TF-managed information with minimal developer intervention.

--- a/README.md
+++ b/README.md
@@ -11,25 +11,30 @@ See the [inital proposal](docs/proposal.md) for more background.
 
 #### Required Tools
 
-[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-[OpenTofu](https://opentofu.org/docs/intro/install/)
-[kubectl](https://kubernetes.io/docs/tasks/tools/)
-[Helm](https://helm.sh/docs/intro/install/)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- [OpenTofu](https://opentofu.org/docs/intro/install/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Helm](https://helm.sh/docs/intro/install/)
 
 
-Areas for Further (Initial) Development:
+### Areas for Further (Initial) Development
 
-1. Variable Management
-    1. Duplication exists between TF inputs, CI workflows, and local scripts.
-    1. A tool like https://github.com/helmfile/helmfile may help with sourcing variables by environment.
-        1. A basic version has been added to deploy revision deltas, further templating would be required.
-    1. As more HOT applications + services are moved to cluster, this will only grow.
-1. Deployment
-    1. Provisioning is currently done in the same workflow (TF, K8s, Helm), mostly as byproduct of initial development phase. Can be further refined.
-    1. GitOps tools like ArgoCD are [under consideration](https://github.com/hotosm/k8s-infra/issues/14)
-    1. Flux [Tofu controller](https://github.com/flux-iac/tofu-controller) may be an analog for base infrastructure (further investigation required).
-1. Bridging TF and Kubernetes
-    1. TF-managed information often needs to be referenced on the cluster
-        1. ex: PostgresCluster CRD requires the role ARN authorized for backups. Role and bucket are created in TF.
-    1. Global cluster resources are provisioned through TF, but argument can be made for their management by K8s. 
-    1. Ideal solution enables cluster resources to reference, mount, inject, etc. TF-managed information with minimal developer intervention.
+#### Variable Management
+
+- Duplication exists between TF inputs, CI workflows, and local scripts.
+- A tool like https://github.com/helmfile/helmfile may help with sourcing variables by environment.
+    - A basic version has been added to deploy revision deltas, further templating would be required.
+- As more HOT applications + services are moved to cluster, this will only grow.
+
+#### Deployment
+
+- Provisioning is currently done in the same workflow (TF, K8s, Helm), mostly as byproduct of initial development phase. Can be further refined.
+- GitOps tools like ArgoCD are [under consideration](https://github.com/hotosm/k8s-infra/issues/14)
+- Flux [Tofu controller](https://github.com/flux-iac/tofu-controller) may be an analog for base infrastructure (further investigation required).
+
+#### Bridging TF and Kubernetes
+
+- TF-managed information often needs to be referenced on the cluster
+    - ex: PostgresCluster CRD requires the role ARN authorized for backups. Role and bucket are created in TF.
+- Global cluster resources are provisioned through TF, but argument can be made for their management by K8s. 
+- Ideal solution enables cluster resources to reference, mount, inject, etc. TF-managed information with minimal developer intervention.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,153 @@
+# Cluster Applications
+
+See [initial migration outline](../proposal.md) for main HOT OSM applications.
+
+Relevant Docs:
+- [kubectl]
+- [Helm]
+
+## Global
+
+### ClusterIssuer
+
+Issue TLS certificates with [Let's Encrypt], via [cert-manager].
+
+See [cert-manager docs] for more on Issuer and ClusterIssuer.
+
+Install:
+```sh
+# ** See helm/eoapi-values.yaml for initial setup **
+$ kubectl apply -f kubernetes/manifests/cluster-issuer.yaml
+```
+
+## eoAPI
+
+Open source Earth Observation (EO) backend supporting Open Aerial Map (OAM).
+
+Site: https://eoapi.dev/
+Chart: https://github.com/developmentseed/eoapi-k8s
+
+Install:
+```sh
+$ helm upgrade --install --set disable_check_for_upgrades=true pgo oci://registry.developers.crunchydata.com/crunchydata/pgo --version $PGO_VERSION
+$ helm repo add eoapi https://devseed.com/eoapi-k8s/
+$ helm upgrade --install --namespace eoapi --create-namespace eoapi eoapi/eoapi \
+    --version $EOAPI_CHART_VERSION \
+    -f kubernetes/helm/eoapi-values.yaml \
+    --set previousVersion=$EOAPI_CHART_VERSION \
+    --set postgrescluster.metadata.annotations."eks\.amazonaws\.com/role-arn"=$S3_BACKUP_ROLE
+```
+
+### helmfile
+
+A basic [helmfile] has been added for GitHub Actions, but its recommended to use outside of CI workflows to maintain consistency.
+
+```sh
+$ helmfile apply
+```
+
+Provided the values match, a similar workflow can be achieved with the Makefile commands if the additional install isn't desired.
+
+### Configuration
+
+See [eoAPI chart docs]. The following sections provide a basic outline of overlays, customizations, and considerations specific to HOT's initial implementation.
+
+#### TLS
+
+Required for [iframing]. See cert-manager docs above and [eoAPI guidance on cert-manager setup]. 
+
+Once a domain has been secured, issuer manifests and chart settings have been made available to provision certificates using [ingress annotations] and Let's Encrypt/[ACME].
+
+Step-by-step instructions can be found in the [eoapi values file](./helm/eoapi-values.yaml). 
+
+#### Backups
+
+Enabled with default settings, see the [PostgresOperator docs] for further customization. 
+
+Uses an [OIDC auth setup] to access S3, which requires propagating TF-managed information to K8s.
+
+> [!NOTE]
+> Further development to bridge and/or reorganize TF and K8s-provisioned resources may remove the need to set a `role-arn` annotation on each release.
+
+#### Monitoring / Observability / Autoscaling
+
+The eoAPI support chart adds Prometheus and Grafana tooling to enable systems analysis, visualization, and custom metrics for autoscaling. 
+
+- [eoAPI support chart setup]: in-depth walkthrough
+- [eoAPI chart configuration]: set HPA behavior for services
+- [eoAPI support chart dependencies]: explore further customization, provider documentation
+
+Currently set to install once TLS is enabled in eoAPI.
+
+## Tips + Commands
+
+### Setup
+
+#### Local Context
+
+```sh
+$ aws eks update-kubeconfig --name <cluster_name>
+```
+
+### Debugging
+
+CLI manual will be most helpful:
+```sh
+$ kubectl --help
+```
+
+#### Examples
+
+Basic cluster overview:
+```sh
+$ kubectl get pod,svc,deploy -A
+```
+
+Shell into default container on pod:
+```sh
+$ kubectl -n <ns> exec -it <pod> -- bash
+# $
+```
+
+Inspect ingress details:
+```sh
+$ kubectl -n <ns> describe ingress/<ingress>
+```
+
+Redirect pod log output to file:
+```sh
+$ kubectl -n <ns> logs <pod> --all-containers=true >> file.log
+```
+
+[kubectl]:
+  https://kubernetes.io/docs/reference/kubectl/
+[Helm]:
+  https://helm.sh/docs/
+[Let's Encrypt]:
+  https://letsencrypt.org/
+[cert-manager]:
+  https://cert-manager.io/
+[cert-manager docs]:
+  https://cert-manager.io/docs/configuration/
+[helmfile]:
+  https://github.com/helmfile/helmfile
+[eoAPI chart docs]:
+  https://github.com/developmentseed/eoapi-k8s/tree/975a26639fa3b8be7d3338220d6ea9c4470d8d15/docs
+[iframing]:
+  https://developmentseed.slack.com/archives/C08B8L61QTT/p1747740182369159?thread_ts=1747314980.658339&cid=C08B8L61QTT
+[eoAPI guidance on cert-manager setup]:
+  https://github.com/developmentseed/eoapi-k8s/blob/main/docs/unified-ingress.md#setting-up-tls-with-cert-manager
+[ingress annotations]:
+  https://cert-manager.io/docs/usage/ingress/
+[ACME]:
+  https://cert-manager.io/docs/configuration/acme/
+[PostgresOperator docs]:
+  https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/backups
+[OIDC auth setup]:
+  https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/backups#using-an-aws-integrated-identity-provider-and-role
+[eoAPI support chart setup]:
+  https://github.com/developmentseed/eoapi-k8s/blob/975a26639fa3b8be7d3338220d6ea9c4470d8d15/docs/autoscaling.md
+[eoAPI chart configuration]:
+  https://github.com/developmentseed/eoapi-k8s/blob/975a26639fa3b8be7d3338220d6ea9c4470d8d15/docs/configuration.md
+[eoAPI support chart dependencies]:
+  https://github.com/developmentseed/eoapi-k8s/blob/975a26639fa3b8be7d3338220d6ea9c4470d8d15/helm-chart/eoapi-support/Chart.yaml

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -10,9 +10,7 @@ Relevant Docs:
 
 ### ClusterIssuer
 
-Issue TLS certificates with [Let's Encrypt], via [cert-manager].
-
-See [cert-manager docs] for more on Issuer and ClusterIssuer.
+Issue TLS certificates for the cluster via [cert-manager]. See also [eoAPI TLS section](#transport-layer-security-tls).
 
 Install:
 ```sh
@@ -38,7 +36,7 @@ $ helm upgrade --install --namespace eoapi --create-namespace eoapi eoapi/eoapi 
     --set postgrescluster.metadata.annotations."eks\.amazonaws\.com/role-arn"=$S3_BACKUP_ROLE
 ```
 
-### helmfile
+#### helmfile
 
 A basic [helmfile] has been added for GitHub Actions, but its recommended to use outside of CI workflows to maintain consistency.
 
@@ -52,13 +50,14 @@ Provided the values match, a similar workflow can be achieved with the Makefile 
 
 See [eoAPI chart docs]. The following sections provide a basic outline of overlays, customizations, and considerations specific to HOT's initial implementation.
 
-#### TLS
+#### Transport Layer Security (TLS)
 
-Required for [iframing]. See cert-manager docs above and [eoAPI guidance on cert-manager setup]. 
+See [cert-manager docs] and [eoAPI guidance on cert-manager setup]. 
 
-Once a domain has been secured, issuer manifests and chart settings have been made available to provision certificates using [ingress annotations] and Let's Encrypt/[ACME].
-
-Step-by-step instructions can be found in the [eoapi values file](./helm/eoapi-values.yaml). 
+- Requires a domain controlled by HOT
+- Issuer manifests and chart settings have been made available to provision certificates using [ingress annotations] and Let's Encrypt/[ACME]
+- Step-by-step instructions can be found in the [eoapi values file](./helm/eoapi-values.yaml)
+- Required for [iframing]
 
 #### Backups
 
@@ -77,7 +76,7 @@ The eoAPI support chart adds Prometheus and Grafana tooling to enable systems an
 - [eoAPI chart configuration]: set HPA behavior for services
 - [eoAPI support chart dependencies]: explore further customization, provider documentation
 
-Currently set to install once TLS is enabled in eoAPI.
+_Currently set to install once TLS is enabled in eoAPI._
 
 ## Tips + Commands
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -56,8 +56,7 @@ See [cert-manager docs] and [eoAPI guidance on cert-manager setup].
 
 - Requires a domain controlled by HOT
 - Issuer manifests and chart settings have been made available to provision certificates using [ingress annotations] and Let's Encrypt/[ACME]
-- Step-by-step instructions can be found in the [eoapi values file](./helm/eoapi-values.yaml)
-- Required for [iframing]
+- Recommend going through staging issuer first to avoid hitting rate limits
 
 #### Backups
 

--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -14,7 +14,7 @@ prometheus:
         # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/enable-access-log: "true"
-        cert-manager.io/cluster-issuer: "letsencrypt-staging"
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
       enabled: true
       ingressClassName: nginx
       hosts:
@@ -34,7 +34,7 @@ grafana:
     annotations:
       nginx.ingress.kubernetes.io/enable-cors: "true"
       nginx.ingress.kubernetes.io/enable-access-log: "true"
-      cert-manager.io/cluster-issuer: "letsencrypt-staging"
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
     enabled: true
     ingressClassName: nginx
     hosts:

--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -9,9 +9,9 @@ prometheus:
       annotations: { }
     ingress:
       annotations:
-        # nginx.ingress.kubernetes.io/auth-type: basic
-        # nginx.ingress.kubernetes.io/auth-secret: eoapi-support-prometheus
-        # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+        nginx.ingress.kubernetes.io/auth-type: basic
+        nginx.ingress.kubernetes.io/auth-secret: eoapi-support-prometheus
+        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/enable-access-log: "true"
         cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -4,10 +4,45 @@ prometheus-adapter:
 
 prometheus:
   server:
+    service:
+      type: ClusterIP
+      annotations: { }
+    ingress:
+      annotations:
+        # nginx.ingress.kubernetes.io/auth-type: basic
+        # nginx.ingress.kubernetes.io/auth-secret: eoapi-support-prometheus
+        # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/enable-access-log: "true"
+        cert-manager.io/cluster-issuer: "letsencrypt-staging"
+      enabled: true
+      ingressClassName: nginx
+      hosts:
+        - metrics.k8s-prod.hotosm.org
+      tls:
+        - secretName: prometheus-server-tls
+          hosts:
+            - metrics.k8s-prod.hotosm.org
     persistentVolume:
       storageClass: gp2
 
 grafana:
+  service:
+    type: ClusterIP
+    annotations: { }
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/enable-access-log: "true"
+      cert-manager.io/cluster-issuer: "letsencrypt-staging"
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - dashboard.k8s-prod.hotosm.org
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - dashboard.k8s-prod.hotosm.org
   datasources:
     datasources.yaml:
       datasources:

--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -1,0 +1,23 @@
+prometheus-adapter:
+  prometheus:
+    url: http://eoapi-support-prometheus-server.eoapi-support.svc.cluster.local
+
+prometheus:
+  server:
+    persistentVolume:
+      storageClass: gp2
+
+grafana:
+  datasources:
+    datasources.yaml:
+      datasources:
+      - name: prometheus
+        orgId: 1
+        type: prometheus
+        url: http://eoapi-support-prometheus-server.eoapi-support.svc.cluster.local
+        access: proxy
+        jsonData:
+          timeInterval: "5s"
+        isDefault: true
+        editable: true
+        version: 1 # This number should be increased when changes are made to update the datasource

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -23,11 +23,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/enable-access-log: "true"
-  #   cert-manager.io/cluster-issuer: "letsencrypt-staging"
-  # host: "k8s.hotosm.org"
-  # tls:
-  #   enabled: true
-  #   secretName: eoapi-tls
+    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  host: "eoapi-prod.imagery-services.k8s-prod.hotosm.org"
+  tls:
+    enabled: true
+    secretName: eoapi-tls
 
 stac:
   image:

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -15,34 +15,34 @@ vector:
   # needed currently, so it is disabled to save on some cluster resources.
   enabled: false
 
-# stac:
-#   image:
-#     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
-#     name: ghcr.io/hotosm/openaerialmap/stac-api
-#     tag: main
-#   command:
-#     - "uvicorn"
-#     - "app.main:app"
-#     - "--host=$(HOST)"
-#     - "--port=$(PORT)"
-#   settings:
-#     envVars:
-#       ##############
-#       # uvicorn
-#       ##############
-#       HOST: "0.0.0.0"
-#       PORT: "8080"
-#       # https://www.uvicorn.org/settings/#production
-#       WEB_CONCURRENCY: "5"
-#       ##############
-#       # stac-fastapi-pgstac
-#       ##############
-#       ENABLE_TRANSACTIONS_EXTENSIONS: "false"
-#       ##############
-#       # stac-fastapi
-#       ##############
-#       STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
-#       STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
+stac:
+  image:
+    # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
+    name: ghcr.io/hotosm/openaerialmap/stac-api
+    tag: main
+  command:
+    - "uvicorn"
+    - "app.main:app"
+    - "--host=$(HOST)"
+    - "--port=$(PORT)"
+  settings:
+    envVars:
+      ##############
+      # uvicorn
+      ##############
+      HOST: "0.0.0.0"
+      PORT: "8080"
+      # https://www.uvicorn.org/settings/#production
+      WEB_CONCURRENCY: "5"
+      ##############
+      # stac-fastapi-pgstac
+      ##############
+      ENABLE_TRANSACTIONS_EXTENSIONS: "false"
+      ##############
+      # stac-fastapi
+      ##############
+      STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
+      STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
 
 postgrescluster:
   backupsEnabled: true

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -4,13 +4,13 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/enable-access-log: "true"
-
+  #   cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  # host: "k8s.hotosm.org"
+  # tls:
+  #   enabled: true
+  #   secretName: eoapi-tls
 
 postgrescluster:
-  # # TODO: bridge alternatives for TF output to CRD annotations
-  # metadata:
-  #   annotations:
-  #     eks.amazonaws.com/role-arn: ""
   backupsEnabled: true
   s3:
     bucket: "pgstac-backup"
@@ -21,13 +21,12 @@ postgrescluster:
   - name: eoapi
     replicas: 1
     dataVolumeClaimSpec:
-      # TODO: gp3 SC
       storageClassName: "gp2"
       accessModes:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "10Gi"
+          storage: "100Gi"
           cpu: "1024m"
           memory: "3048Mi"
 

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -29,6 +29,30 @@ ingress:
   #   enabled: true
   #   secretName: eoapi-tls
 
+stac:
+  image:
+    # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
+    name: ghcr.io/hotosm/openaerialmap/stac-api
+    tag: main
+  settings:
+    envVars:
+      ##############
+      # uvicorn
+      ##############
+      HOST: "0.0.0.0"
+      PORT: "8080"
+      # https://www.uvicorn.org/settings/#production
+      WEB_CONCURRENCY: "5"
+      ##############
+      # stac-fastapi-pgstac
+      ##############
+      ENABLE_TRANSACTIONS_EXTENSIONS: "false"
+      ##############
+      # stac-fastapi
+      ##############
+      STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
+      STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
+
 postgrescluster:
   backupsEnabled: true
   s3:

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -23,11 +23,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/enable-access-log: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-staging"
-  host: "eoapi-prod.imagery-services.k8s-prod.hotosm.org"
-  tls:
-    enabled: true
-    secretName: eoapi-tls
+  #   cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  ## host: "eoapi-backend-prod.imagery-services.k8s-prod.hotosm.org"
+  ## host: "eoapi-prod.imagery-services.k8s-prod.hotosm.org"
+  # tls:
+  #   enabled: true
+  #   secretName: eoapi-tls
 
 stac:
   image:

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -15,34 +15,34 @@ vector:
   # needed currently, so it is disabled to save on some cluster resources.
   enabled: false
 
-stac:
-  image:
-    # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
-    name: ghcr.io/hotosm/openaerialmap/stac-api
-    tag: main
-  command:
-    - "uvicorn"
-    - "app.main:app"
-    - "--host=$(HOST)"
-    - "--port=$(PORT)"
-  settings:
-    envVars:
-      ##############
-      # uvicorn
-      ##############
-      HOST: "0.0.0.0"
-      PORT: "8080"
-      # https://www.uvicorn.org/settings/#production
-      WEB_CONCURRENCY: "5"
-      ##############
-      # stac-fastapi-pgstac
-      ##############
-      ENABLE_TRANSACTIONS_EXTENSIONS: "false"
-      ##############
-      # stac-fastapi
-      ##############
-      STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
-      STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
+# stac:
+#   image:
+#     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
+#     name: ghcr.io/hotosm/openaerialmap/stac-api
+#     tag: main
+#   command:
+#     - "uvicorn"
+#     - "app.main:app"
+#     - "--host=$(HOST)"
+#     - "--port=$(PORT)"
+#   settings:
+#     envVars:
+#       ##############
+#       # uvicorn
+#       ##############
+#       HOST: "0.0.0.0"
+#       PORT: "8080"
+#       # https://www.uvicorn.org/settings/#production
+#       WEB_CONCURRENCY: "5"
+#       ##############
+#       # stac-fastapi-pgstac
+#       ##############
+#       ENABLE_TRANSACTIONS_EXTENSIONS: "false"
+#       ##############
+#       # stac-fastapi
+#       ##############
+#       STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
+#       STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
 
 postgrescluster:
   backupsEnabled: true

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -30,11 +30,21 @@ ingress:
   #   enabled: true
   #   secretName: eoapi-tls
 
+vector:
+  # The vector service that provides OGC Features API and vector tiles isn't
+  # needed currently, so it is disabled to save on some cluster resources.
+  enabled: false
+
 stac:
   image:
     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
     name: ghcr.io/hotosm/openaerialmap/stac-api
     tag: main
+  command:
+    - "uvicorn"
+    - "app.main:app"
+    - "--host=$(HOST)"
+    - "--port=$(PORT)"
   settings:
     envVars:
       ##############

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -32,7 +32,7 @@ ingress:
 postgrescluster:
   backupsEnabled: true
   s3:
-    bucket: "pgstac-backup"
+    bucket: "hotosm-pgstac-backup"
     endpoint: "s3.us-east-1.amazonaws.com"
     region: "us-east-1"
     keyType: "web-id"

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -1,29 +1,10 @@
-# Enabling TLS
-#
-# The following implemention uses ingress annotations (https://cert-manager.io/docs/usage/ingress/)
-# and Let's Encrypt/ACME (https://cert-manager.io/docs/configuration/acme/) to provision certificates.
-#
-# 1. Set up a DNS entry, e.g. k8s.hotosm.org, and provide it under `ingress.host`
-#    https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html
-# 2. Test with the staging issuer first to avoid hitting rate limits
-#    `kubectl apply -f kubernetes/manifests/cluster-issuer-staging.yaml`
-# 3. Uncomment the cert-manager annotation, and the ingress.host + ingress.tls blocks (L26-30).
-# 4. Update the helm release and confirm certificate issued successfully
-#    `kubectl describe certificate/eoapi-tls -n eoapi`
-#    `kubectl describe secret/eoapi-tls -n eoapi`
-# 5. Verify the contact email provided under spec.acme.email and install production issuer
-#    `kubectl apply -f kubernetes/manifests/cluster-issuer.yaml`
-# 6. Change the value of the cert-manager.io/cluster-issuer annotation to: "letsencrypt-prod"
-# 7. Update the helm release and delete the existing secret to update the issuer
-#    `kubectl delete secret/eoapi-tls -n eoapi`
-
 ingress:
   annotations:
     # increase the max body size to 100MB
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/enable-access-log: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
   host: "oam-eoapi-prod.imagery-services.k8s-prod.hotosm.org"
   tls:
     enabled: true

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -1,3 +1,22 @@
+# Enabling TLS
+#
+# The following implemention uses ingress annotations (https://cert-manager.io/docs/usage/ingress/)
+# and Let's Encrypt/ACME (https://cert-manager.io/docs/configuration/acme/) to provision certificates.
+#
+# 1. Set up a DNS entry, e.g. k8s.hotosm.org, and provide it under `ingress.host`
+#    https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html
+# 2. Test with the staging issuer first to avoid hitting rate limits
+#    `kubectl apply -f kubernetes/manifests/cluster-issuer-staging.yaml`
+# 3. Uncomment the cert-manager annotation, and the ingress.host + ingress.tls blocks (L26-30).
+# 4. Update the helm release and confirm certificate issued successfully
+#    `kubectl describe certificate/eoapi-tls -n eoapi`
+#    `kubectl describe secret/eoapi-tls -n eoapi`
+# 5. Verify the contact email provided under spec.acme.email and install production issuer
+#    `kubectl apply -f kubernetes/manifests/cluster-issuer.yaml`
+# 6. Change the value of the cert-manager.io/cluster-issuer annotation to: "letsencrypt-prod"
+# 7. Update the helm release and delete the existing secret to update the issuer
+#    `kubectl delete secret/eoapi-tls -n eoapi`
+
 ingress:
   annotations:
     # increase the max body size to 100MB

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -23,12 +23,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/enable-access-log: "true"
-  #   cert-manager.io/cluster-issuer: "letsencrypt-staging"
-  ## host: "eoapi-backend-prod.imagery-services.k8s-prod.hotosm.org"
-  ## host: "eoapi-prod.imagery-services.k8s-prod.hotosm.org"
-  # tls:
-  #   enabled: true
-  #   secretName: eoapi-tls
+    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  host: "oam-eoapi-prod.imagery-services.k8s-prod.hotosm.org"
+  tls:
+    enabled: true
+    secretName: eoapi-tls
 
 vector:
   # The vector service that provides OGC Features API and vector tiles isn't

--- a/kubernetes/helm/helmfile.yaml.gotmpl
+++ b/kubernetes/helm/helmfile.yaml.gotmpl
@@ -1,0 +1,28 @@
+releases:
+  - name: eoapi
+    namespace: eoapi
+    chart: eoapi/eoapi
+    version: 0.7.1
+    needs: [default/pgo]
+    values:
+      - eoapi-values.yaml
+      - postgrescluster:
+          metadata:
+            annotations:
+              eks.amazonaws.com/role-arn: {{ env "S3_BACKUP_ROLE" }}
+    set:
+      - name: previousVersion
+        value: 0.7.1
+
+  - name: pgo
+    namespace: default
+    chart: oci://registry.developers.crunchydata.com/crunchydata/pgo
+    version: 5.7.4
+    set:
+      - name: disable_check_for_upgrades
+        value: true
+
+
+repositories:
+  - name: eoapi
+    url: https://devseed.com/eoapi-k8s/

--- a/kubernetes/helm/helmfile.yaml.gotmpl
+++ b/kubernetes/helm/helmfile.yaml.gotmpl
@@ -27,7 +27,7 @@ releases:
     chart: eoapi/eoapi-support
     version: 0.1.7
     needs: [eoapi/eoapi]
-    installed: {{ readFile "eoapi-values.yaml" | fromYaml | get "foo" false }}
+    installed: {{ readFile "eoapi-values.yaml" | fromYaml | get "ingress.tls.enabled" false }}
     values:
       - eoapi-support-values.yaml
 

--- a/kubernetes/helm/helmfile.yaml.gotmpl
+++ b/kubernetes/helm/helmfile.yaml.gotmpl
@@ -27,7 +27,7 @@ releases:
     chart: eoapi/eoapi-support
     version: 0.1.7
     needs: [eoapi/eoapi]
-    installed: {{ readFile "eoapi-values.yaml" | fromYaml | get "ingress.tls.enabled" false }}
+    installed: {{ readFile "eoapi-values.yaml" | fromYaml | get "foo" false }}
     values:
       - eoapi-support-values.yaml
 

--- a/kubernetes/helm/helmfile.yaml.gotmpl
+++ b/kubernetes/helm/helmfile.yaml.gotmpl
@@ -22,6 +22,15 @@ releases:
       - name: disable_check_for_upgrades
         value: true
 
+  - name: eoapi-support
+    namespace: eoapi-support
+    chart: eoapi/eoapi-support
+    version: 0.1.7
+    needs: [eoapi/eoapi]
+    installed: {{ readFile "eoapi-values.yaml" | fromYaml | get "ingress.tls.enabled" false }}
+    values:
+      - eoapi-support-values.yaml
+
 
 repositories:
   - name: eoapi

--- a/kubernetes/manifests/cluster-issuer-staging.yaml
+++ b/kubernetes/manifests/cluster-issuer-staging.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: dev@hotosm.org
+    email: sysadmin@hotosm.org
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:

--- a/kubernetes/manifests/cluster-issuer-staging.yaml
+++ b/kubernetes/manifests/cluster-issuer-staging.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: dev@hotosm.org
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/kubernetes/manifests/cluster-issuer.yaml
+++ b/kubernetes/manifests/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: dev@hotosm.org
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/kubernetes/manifests/cluster-issuer.yaml
+++ b/kubernetes/manifests/cluster-issuer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: dev@hotosm.org
+    email: sysadmin@hotosm.org
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:

--- a/kubernetes/manifests/sync-maxar.yaml
+++ b/kubernetes/manifests/sync-maxar.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stac-ingest-maxar
+  namespace: eoapi
+  labels:
+    app: stac-ingest-maxar
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: stac-ingest-maxar
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: stac-ingest-maxar
+              image: ghcr.io/hotosm/openaerialmap/stac-ingester:main
+              resources:
+                limits:
+                  cpu: "768m"
+                  memory: "4096Mi"
+                requests:
+                  cpu: "256m"
+                  memory: "3072Mi"
+              command:
+                - "/bin/sh"
+                - "-c"
+              args:
+                - |
+                  # Exit immediately if a command exits with a non-zero status
+                  set -e
+
+                  # Database connection configured through standard PG* environment variables
+                  # Environment variables are already set by the container
+
+                  echo "Beginning sync"
+                  hotosm sync-maxar --uploaded-since 86700
+
+                  echo "Job complete"
+              env:
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: eoapi-pguser-eoapi
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: eoapi-pguser-eoapi
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: eoapi-pguser-eoapi
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: eoapi-pguser-eoapi
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: dbname
+                      name: eoapi-pguser-eoapi
+      backoffLimit: 2

--- a/kubernetes/manifests/sync-maxar.yaml
+++ b/kubernetes/manifests/sync-maxar.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     app: stac-ingest-maxar
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 0 31 2 *"
+  # schedule: "0 0 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/manifests/sync-oam.yaml
+++ b/kubernetes/manifests/sync-oam.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     app: stac-ingest-oam
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "0 0 31 2 *"
+  # schedule: "*/30 * * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/manifests/sync-oam.yaml
+++ b/kubernetes/manifests/sync-oam.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stac-ingest-oam
+  namespace: eoapi
+  labels:
+    app: stac-ingest-oam
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: stac-ingest-oam
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: stac-ingest-oam
+              image: ghcr.io/hotosm/openaerialmap/stac-ingester:main
+              resources:
+                limits:
+                  cpu: "768m"
+                  memory: "4096Mi"
+                requests:
+                  cpu: "256m"
+                  memory: "3072Mi"
+              command:
+                - "/bin/sh"
+                - "-c"
+              args:
+                - |
+                  # Exit immediately if a command exits with a non-zero status
+                  set -e
+
+                  # Database connection configured through standard PG* environment variables
+                  # Environment variables are already set by the container
+
+                  echo "Beginning sync"
+                  hotosm sync-oam --uploaded-since 2100
+
+                  echo "Job complete"
+              env:
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: eoapi-pguser-eoapi
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      key: port
+                      name: eoapi-pguser-eoapi
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: host
+                      name: eoapi-pguser-eoapi
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: eoapi-pguser-eoapi
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: dbname
+                      name: eoapi-pguser-eoapi
+      backoffLimit: 3

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,3 +1,111 @@
-// TODO 🚧
+# Cluster Infrastructure
 
-https://github.com/developmentseed/eoapi-k8s-terraform
+See [original proposal](../proposal.md) for background.
+
+Defines AWS infrastructure for an EKS cluster managed via OpenTofu. The initial setup is based on an [eoAPI-compatible build].
+
+Resource Overview (AWS):
+- Control Plane (EKS v1.32)
+- Node Group (EC2 Amazon Linux + ASG)
+- Dedicated VPC
+- Shared cluster resources (ingress, autoscaler, certificate manager)
+- Block storage (EBS)
+- Bucket provisioning (S3)
+- State locking remote backend (S3 + Dynamo)
+    - ([S3-only locking expected next release](https://github.com/opentofu/opentofu/issues/599))
+
+Relevant Docs:
+- [AWS EKS]
+- [OpenTofu]
+
+
+## Note
+
+Reconfigure the backend before running any `tofu` commands outside of GitHub Actions to avoid colocating local state with live state.
+
+```tf
+# ./versions.tf
+
+terraform {
+  # Change backend or use different buckets/tables
+  backend "s3" { }
+}
+```
+
+OpenTofu supports the use of [variables in backend configuration](https://opentofu.org/docs/language/settings/backends/configuration/#variables-and-locals). The provided `local.tfvars` file intentionally omits state resources to prompt the user if new values aren't defined in an s3 backend.
+
+
+## Tips + Commands
+
+### Setup
+
+#### AWS Auth
+
+OpenTofu needs to connect with AWS for most all operations.
+
+Make sure the AWS CLI is [installed](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html) with a profile configured to access the target deployment account/region. Setup details vary based on organization policies, principal types, authentication methods, etc.
+
+Non-default AWS credentials are typically set per session:
+```sh
+$ export AWS_PROFILE=<profile>
+$ tofu plan #...
+$ tofu apply #...
+$ #...
+```
+Or per command:
+```sh
+$ AWS_PROFILE=<profile> tofu plan #...
+$ AWS_PROFILE=<profile> tofu apply #...
+$ AWS_PROFILE=<profile> #...
+```
+See [credential precedence] for other sourcing options. 
+
+#### Working Directory
+
+OpenTofu operations reference the current working directory. 
+
+Either switch to the (root) module _before_ running `tofu` commands:
+```sh
+$ cd terraform
+$ tofu plan
+```
+Or reference the correct directory _in_ `tofu` commands:
+```sh
+$ tofu -chdir=terraform plan
+```
+
+### Basic Provision + Teardown
+
+```sh
+$ tofu init
+# ...
+# OpenTofu has been successfully initialized!
+```
+```sh
+$ tofu validate
+# Success! The configuration is valid.
+```
+```sh
+$ tofu plan
+# ...
+# Plan: X to add, Y to change, Z to destroy.
+```
+```sh
+$ tofu apply
+# ...
+# Apply complete! Resources: X added, Y changed, Z destroyed.
+```
+```sh
+$ tofu destroy
+# ...
+# Destroy complete! Resources: X destroyed.
+```
+
+[AWS EKS]:
+  https://docs.aws.amazon.com/eks/
+[OpenTofu]:
+  https://opentofu.org/docs/
+[eoAPI-compatible build]:
+  https://github.com/developmentseed/eoapi-k8s-terraform
+[credential precedence]:
+  https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-configure.html

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,34 +45,34 @@ OpenTofu needs to connect with AWS for most all operations.
 
 Make sure the AWS CLI is [installed](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html) with a profile configured to access the target deployment account/region. Setup details vary based on organization policies, principal types, authentication methods, etc.
 
-Non-default AWS credentials are typically set per session:
-```sh
-$ export AWS_PROFILE=<profile>
-$ tofu plan #...
-$ tofu apply #...
-$ #...
-```
-Or per command:
-```sh
-$ AWS_PROFILE=<profile> tofu plan #...
-$ AWS_PROFILE=<profile> tofu apply #...
-$ AWS_PROFILE=<profile> #...
-```
-See [credential precedence] for other sourcing options. 
+- Non-default AWS credentials are typically set per session:
+  ```sh
+  $ export AWS_PROFILE=<profile>
+  $ tofu plan #...
+  $ tofu apply #...
+  $ #...
+  ```
+- Or per command:
+  ```sh
+  $ AWS_PROFILE=<profile> tofu plan #...
+  $ AWS_PROFILE=<profile> tofu apply #...
+  $ AWS_PROFILE=<profile> #...
+  ```
+- See [credential precedence] for other sourcing options. 
 
 #### Working Directory
 
 OpenTofu operations reference the current working directory. 
 
-Either switch to the (root) module _before_ running `tofu` commands:
-```sh
-$ cd terraform
-$ tofu plan
-```
-Or reference the correct directory _in_ `tofu` commands:
-```sh
-$ tofu -chdir=terraform plan
-```
+- Either switch to the (root) module _before_ running `tofu` commands:
+  ```sh
+  $ cd terraform
+  $ tofu plan
+  ```
+- Or reference the correct directory _in_ `tofu` commands:
+  ```sh
+  $ tofu -chdir=terraform plan
+  ```
 
 ### Basic Provision + Teardown
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,7 +12,7 @@ data "aws_availability_zones" "available" {
 
 locals {
   cluster_prefix = "hotosm-${var.environment}"
-  cluster_admins = concat(var.cluster_admin_access_role_arns, [var.cluster_ci_access_role_arn])
+  cluster_admins = concat([var.cluster_ci_access_role_arn], var.cluster_admin_access_role_arns)
   azs            = slice(sort(data.aws_availability_zones.available.names), 0, min(4, length(data.aws_availability_zones.available.names)))
   vpc_cidr       = "10.0.0.0/16"
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -9,5 +9,5 @@ module "vpc" {
 
   azs             = local.azs
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
-  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 64)]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,22 @@ variable "region" {
   EOT
 }
 
+variable "state_bucket" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+  S3 bucket for remote state backend
+  EOT
+}
+
+variable "lock_table" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+  Dynamo table to use for consistency checks (when using an s3 backend)
+  EOT
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/terraform/vars/local.tfvars
+++ b/terraform/vars/local.tfvars
@@ -1,0 +1,2 @@
+environment = "develop"
+region      = "us-east-1"

--- a/terraform/vars/production.tfvars
+++ b/terraform/vars/production.tfvars
@@ -1,5 +1,7 @@
 environment   = "production"
 region        = "us-east-1"
+state_bucket  = "hotosm-terraform"
+lock_table    = "k8s-infra"
 instance_type = "t3.xlarge"
 bucket_names  = ["pgstac-backup", ]
 tags = {

--- a/terraform/vars/production.tfvars
+++ b/terraform/vars/production.tfvars
@@ -3,7 +3,7 @@ region        = "us-east-1"
 state_bucket  = "hotosm-terraform"
 lock_table    = "k8s-infra"
 instance_type = "t3.xlarge"
-bucket_names  = ["pgstac-backup", ]
+bucket_names  = ["hotosm-pgstac-backup", ]
 tags = {
   project = "k8s-control"
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
     region         = var.region
-    bucket         = "hotosm-terraform"
+    bucket         = var.state_bucket
     key            = "${var.environment}/k8s-infra/terraform.tfstate"
-    dynamodb_table = "k8s-infra"
+    dynamodb_table = var.lock_table
   }
 
   required_providers {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

https://github.com/hotosm/OpenAerialMap/issues/193

## Describe this PR

- Adds deployment via [helmfile](https://github.com/helmfile/helmfile):
    - Ensures prerequisite releases are installed
    - Creates new revision on change only
    - Enables further customization, templating, isolation, etc.
- Adds Prometheus and Grafana tooling via eoAPI support chart:
    - Enables custom metrics for HPA
    - Monitoring, observability, and alerting for admins
- Adds local TF vars for added buffer during initial development
    - Production values only used in GitHub Actions
    - Local values are intentionally sparse
    - Motivated by https://github.com/hotosm/OpenAerialMap/issues/194#issuecomment-2914343924
- Documents initial implementation, basic setup, and areas for further improvement
- Fixes CIDR collision during subnet generation


## Screenshots
Grafana:
<img width="1357" alt="grafana" src="https://github.com/user-attachments/assets/2e541123-dfe6-4a56-8127-6c8e3905dcc3" />
Prometheus:
<img width="1346" alt="prometheus" src="https://github.com/user-attachments/assets/4b04ba56-4051-4be7-8ce3-230d2a7af0bf" />

## Review Guide

1. Spin up a local cluster (e.g. [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/docs/), [Docker Desktop](https://docs.docker.com/desktop/features/kubernetes/))
2. Install [helm](https://helm.sh/docs/intro/install/)
3. Install [helmfile](https://helmfile.readthedocs.io/en/latest/#installation) (or run in container)
4. Add global resources
    <details>
    <summary>helmfile.yaml</summary>

    ```yaml
    releases:
      - name: cluster-autoscaler
        namespace: cluster-autoscaler
        chart: cluster-autoscaler/cluster-autoscaler
        version: 9.46.6
        values:
          - autoDiscovery:
              clusterName: hotosm-development-cluster
            awsRegion: us-east-1

      - name: ingress
        namespace: ingress-nginx
        chart: ingress-nginx/ingress-nginx
        version: 4.12.1
        values:
          - controller:
              enableLatencyMetrics: true
              metrics:
                enabled: true
                service:
                  annotations:
                    prometheus.io/scrape: "true"
                    prometheus.io/port: "10254"

      - name: cert-manager
        chart: cert-manager/cert-manager
        namespace: cert-manager
        version: 1.17.1
        values:
          - installCRDs: true

    repositories:
      - name: cluster-autoscaler
        url: https://kubernetes.github.io/autoscaler
      - name: ingress-nginx
        url: https://kubernetes.github.io/ingress-nginx
      - name: cert-manager
        url: https://charts.jetstack.io
    ```
    </details>
    
    ```sh
    $ helmfile apply
    ```
5. Pull down this branch
6. Initialize helmfile, recommend installing the diff plugin to more easily view changes
    ```sh
    $ cd kubernetes/helm
    $ helmfile init
    ```
7. Set environment and apply helmfile → expect successful pgo + eoapi install
    ```sh
    $ export S3_BACKUP_ROLE=arn:aws:iam::0123456789:role/s3-backup
    $ sed -i '' '43d' eoapi-values.yaml # If not installing on AWS, delete setting referencing specific storage class
    $ helmfile apply
    # ...
    # UPDATED RELEASES:
    # NAME
    # pgo     ...
    # eoapi   ...
    ```
8. Apply again without changes → expect no updates
    ```sh
    $ helmfile apply
    # Comparing release=pgo, ...
    # Comparing release=eoapi, ...
    ```
9. Modify eoapi input and reapply → expect successful eoapi update and pgo skipped
    ```sh
    $ sed -i '' 's/100m/101m/' eoapi-values.yaml 
    $ helmfile apply
    # ...
    # UPDATED RELEASES:
    # NAME
    # eoapi   ...
    
    $ helm list -A
    # NAME              	REVISION
    # eoapi     ...     	2
    # pgo       ...     	1
    ```
10. Explore cluster resources + deployed app → expect available eoapi services and interface
    ```sh
    $ kubectl get pod,svc,deploy -A
    $ kubectl -n ingress-nginx get svc/ingress-ingress-nginx-controller \
        -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}'
    # <hostname>
    # ^^^^^^^^^ Plug output into browser
    ```
11. Set eoapi value `ingress.tls.enabled: true` and reapply → expect eoapi-support chart to be installed
    ```sh
    $ sed -i '' '28,29s/# //' eoapi-values.yaml
    $ helmfile apply
    # ...
    # UPDATED RELEASES:
    # NAME
    # eoapi-support   ...
    ```
    **NOTE**: this chart should be installed when TLS is setup. We're using a shortcut for local testing, so we won't be able to interact with it.
12. ```sh
    $ helmfile destroy
    # ...
    # DELETED RELEASES:
    # NAME 
    # eoapi-support   ...
    # eoapi           ...
    # pgo             ...
    ```
