### PR TITLE
feat: use STAC API container from OpenAerialMap

### DIFF
--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -34,6 +34,24 @@ stac:
     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
     name: ghcr.io/hotosm/openaerialmap/stac-api
     tag: main
+  settings:
+    envVars:
+      ##############
+      # uvicorn
+      ##############
+      HOST: "0.0.0.0"
+      PORT: "8080"
+      # https://www.uvicorn.org/settings/#production
+      WEB_CONCURRENCY: "5"
+      ##############
+      # stac-fastapi-pgstac
+      ##############
+      ENABLE_TRANSACTIONS_EXTENSIONS: "false"
+      ##############
+      # stac-fastapi
+      ##############
+      STAC_FASTAPI_TITLE: "STAC FastAPI for OpenAerialMap"
+      STAC_FASTAPI_DESCRIPTION: "STAC FastAPI deployment for the OpenAerialMap and open imagery catalogs."
 
 postgrescluster:
   backupsEnabled: true

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -29,6 +29,12 @@ ingress:
   #   enabled: true
   #   secretName: eoapi-tls
 
+stac:
+  image:
+    # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
+    name: ghcr.io/hotosm/openaerialmap/stac-api
+    tag: main
+
 postgrescluster:
   backupsEnabled: true
   s3:


### PR DESCRIPTION
## Description

>[!IMPORTANT]
>I'm targeting a work in progress branch of `k8s-infra` because the PR makes significant changes that would cause conflicts. I'm also hoping to avoid making alterations to any deployments in the dev environment beyond the changes in this PR, so basing my branch here off of the @aliziel's PR branch will reduce that possibility.

This PR closes https://github.com/hotosm/OpenAerialMap/issues/191 by replacing the "off the shelf" version of eoAPI's STAC API with a slightly customized version for OpenAerialMap. By replacing the "out of the box" container reference with our own we can,

1. Disable the transactions endpoints for now.
2. Eventually setup authentication for the STAC API inside this app, which would allow us to re-enable the transactions endpoints safely.
3. ... add any other customizations we might want

I also added an override for the envvars to,
* Include the ones we're [overriding from upstream](https://github.com/developmentseed/eoapi-k8s/blob/v0.7.4/helm-chart/eoapi/values.yaml#L384-L391)
* Include the toggle for enabling the "transactions extensions" so we can turn that on without a code change.
* Define some of the FastAPI app settings from [stac-fastapi](https://github.com/stac-utils/stac-fastapi/blob/5.2.1/stac_fastapi/types/stac_fastapi/types/config.py#L24-L27), mostly to make the API docs page look nicer.