### PR TITLE
fix: override STAC API command and disable vector (TiPG)

### DIFF
--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -30,6 +30,11 @@ ingress:
   #   enabled: true
   #   secretName: eoapi-tls
 
+vector:
+  # The vector service that provides OGC Features API and vector tiles isn't
+  # needed currently, so it is disabled to save on some cluster resources.
+  enabled: false
+
 stac:
   image:
     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api

--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -35,6 +35,11 @@ stac:
     # From https://github.com/hotosm/OpenAerialMap/tree/main/backend/stac-api
     name: ghcr.io/hotosm/openaerialmap/stac-api
     tag: main
+  command:
+    - "uvicorn"
+    - "app.main:app"
+    - "--host=$(HOST)"
+    - "--port=$(PORT)"
   settings:
     envVars:
       ##############


### PR DESCRIPTION
## Description

This PR is a fix for #19 which forgot to override the container command. The Helm chart we're using has a [command definition](https://github.com/developmentseed/eoapi-k8s/blob/main/helm-chart/eoapi/values.yaml#L362C1-L367C1) that runs the "out of the box" FastAPI application for (PgSTAC flavored) STAC FastAPI, so we need to override that with our own.

I also added an override to disable the "vector" service ([TiPG](https://github.com/developmentseed/tipg)) since we don't have vector datasets to serve and disabling it can save on some cluster resources.