### PR TITLE
Add autoscaling and set higher cpu for raster-eoapi service

### DIFF
--- a/kubernetes/helm/eoapi-values.yaml
+++ b/kubernetes/helm/eoapi-values.yaml
@@ -37,7 +37,7 @@ raster:
     resources:
       requests:
         cpu: "1024m"
-        memory: "3Gi"
+        memory: "2Gi"
       limits:
         cpu: "2048m"
         memory: "4Gi"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

The raster renderer has been crashing with a single user (me) attempting to use calls such as 
```
[https://api.imagery.hotosm.org/raster/searches/867568a0734dd1f665da93a5a5e2a5ec/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?assets=visual](https://api.imagery.hotosm.org/raster/searches/867568a0734dd1f665da93a5a5e2a5ec/tiles/WebMercatorQuad/%7Bz%7D/%7Bx%7D/%7By%7D@1x.png?assets=visual)
```

Default cpu/mem config for the pods: 
```
     Limits:
      cpu:     768m
      memory:  4Gi
    Requests:
      cpu:      256m
      memory:   3Gi
```

0.25 of a vCPU is probably way too small, new config (below) should fix most of the problems. 
```
      requests:
        cpu: "1024m"
        memory: "3Gi"
      limits:
        cpu: "2048m"
        memory: "4Gi"
```

Additionally, we enable [autoscaling](https://github.com/developmentseed/eoapi-k8s/blob/main/docs/autoscaling.md) for the raster-eoapi pod. Current scaling target is 85% CPU usage- This needs discussion, and potentially load-testing. 

## Screenshots

grafana dashboard showing some of the metrics leading to these changes: 
<img width="720" height="376" alt="image" src="https://github.com/user-attachments/assets/ce7f2647-f0d5-475b-b1c3-695d1341e477" />


