### PR TITLE
Remove gp2 storageclass from tofu, as it was deployed manually in cluster

### DIFF
--- a/terraform/addons.tf
+++ b/terraform/addons.tf
@@ -56,23 +56,3 @@ resource "kubernetes_storage_class" "gp3" {
   }
   depends_on = [aws_eks_addon.ebs_provisioner]
 }
-
-# FIXME
-# FIXME
-# Legacy GP2 provider (temporary, to be deleted post-migration)
-# This is used by eoAPI currently
-# If we migrate the CrunchyDB --> CloudNativeDB, then update vars
-# we can probably delete this after
-# https://github.com/hotosm/k8s-infra/issues/38
-resource "kubernetes_storage_class" "gp2" {
-  metadata {
-    name = "gp2"
-  }
-  storage_provisioner = "kubernetes.io/aws-ebs"
-  reclaim_policy      = "Delete"
-  volume_binding_mode = "WaitForFirstConsumer"
-  parameters = {
-    type   = "gp2"
-    fsType = "ext4"
-  }
-}


### PR DESCRIPTION
Follow on from https://github.com/hotosm/k8s-infra/pull/44
For https://github.com/hotosm/k8s-infra/issues/38
https://github.com/hotosm/k8s-infra/actions/runs/19254434524/job/55046123008

Deploying gp2 storageclass failed as it exists already / there is a conflict (it was deployed manually for some reason).
I simply removed it for now. We can delete it manually after migration.