### PR TITLE
Fix login backend health check endpoint

### DIFF
--- a/apps/login/backend-deployment.yaml
+++ b/apps/login/backend-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               key: osm-client-secret
         livenessProbe:
           httpGet:
-            path: /api/health
+            path: /health
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -55,7 +55,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /api/health
+            path: /health
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 5


### PR DESCRIPTION
Fixes health check path from `/api/health` to `/health` to match the actual endpoint in the backend code.

This resolves the pod restart issue where K8s was checking `/api/health` (404) instead of `/health` (200).

Related to the initial deployment in the previous PR.