### PR TITLE
Add ingress priority annotations

### DIFF
--- a/apps/hanko/ingress.yaml
+++ b/apps/hanko/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-access-log: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/priority: "1"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: login.hotosm.org
     external-dns.alpha.kubernetes.io/ttl: "300"

--- a/apps/login/backend-ingress.yaml
+++ b/apps/login/backend-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-access-log: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/priority: "20"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: login.hotosm.org
     external-dns.alpha.kubernetes.io/ttl: "300"

--- a/apps/login/frontend-ingress.yaml
+++ b/apps/login/frontend-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/priority: "10"
+    nginx.ingress.kubernetes.io/priority: "15"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: login.hotosm.org
     external-dns.alpha.kubernetes.io/ttl: "300"
@@ -47,7 +47,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-access-log: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/priority: "10"
+    nginx.ingress.kubernetes.io/priority: "15"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     external-dns.alpha.kubernetes.io/hostname: login.hotosm.org
     external-dns.alpha.kubernetes.io/ttl: "300"


### PR DESCRIPTION
Adds priority annotations to ingresses to ensure correct routing order.

**Priority order:**
- Backend (20): `/api/*` and `/me` evaluated first
- Frontend (15): `/login/*` and `/assets/*` evaluated second  
- Hanko (1): `/` catch-all evaluated last

Tested in minikube.