### PR TITLE
Enable httpOnly cookies for SSO

### DIFF
--- a/apps/hanko/deployment.yaml
+++ b/apps/hanko/deployment.yaml
@@ -26,6 +26,17 @@ spec:
             - all
             - '--config'
             - /etc/config/config.yaml
+          env:
+            - name: SESSION_COOKIE_DOMAIN
+              value: ".hotosm.org"
+            - name: SESSION_COOKIE_HTTP_ONLY
+              value: "true"
+            - name: SESSION_COOKIE_SAME_SITE
+              value: "lax"
+            - name: SESSION_COOKIE_SECURE
+              value: "true"
+            - name: THIRD_PARTY_COOKIE_DOMAIN
+              value: ".hotosm.org"
           ports:
             - name: http-public
               containerPort: 8000


### PR DESCRIPTION
Configure Hanko to set httpOnly cookies with proper domain for cross-subdomain SSO.