### PR TITLE
Fix karpenter ecr source repo

### DIFF
--- a/apps/karpenter.yaml
+++ b/apps/karpenter.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   sources:
     # Helm chart + values
-    - repoURL: oci://public.ecr.aws/karpenter
+    - repoURL: oci://public.ecr.aws/karpenter/karpenter
       chart: karpenter
       targetRevision: 1.8.6
       helm:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)


## Describe this PR

ArgoCD reported a mismatch in the source, due to wrong name for the karpenter image: 
<img width="1430" height="133" alt="image" src="https://github.com/user-attachments/assets/791eefcd-62c5-4839-82d3-f2bfa5c07cce" />

