### PR TITLE
Add missing ListInstanceProfiles perm to karpenter controller policy

### DIFF
--- a/terraform/karpenter.tf
+++ b/terraform/karpenter.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "ec2:CreateLaunchTemplate",
       "ec2:CreateFleet",
       "ec2:DescribeSpotPriceHistory",
-      "pricing:GetProducts"
+      "pricing:GetProducts",
+      "iam:ListInstanceProfiles"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes logged error: 
```json
{"level":"ERROR","time":"2026-01-29T19:57:55.449Z","logger":"controller","message":"Reconciler error","commit":"f29079c","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"autoscale"},"namespace":"","name":"autoscale","reconcileID":"57fc8982-0d89-4937-94dd-9da1fb9be971","aws-error-code":"AccessDenied","aws-operation-name":"GetInstanceProfile","aws-request-id":"6ebd2441-6249-4973-a9cc-52151f00d8f3","aws-service-name":"IAM","aws-status-code":403,"instance-profile":"hotosm-production-cluster_13539192016233945975","error":"creating instance profile, getting instance profile, operation error IAM: GetInstanceProfile, https response error StatusCode: 403, RequestID: 6ebd2441-6249-4973-a9cc-52151f00d8f3, api error AccessDenied: User: arn:aws:sts::670261699094:assumed-role/hotosm-production-karpenter-controller/1769716252034557374 is not authorized to perform: iam:GetInstanceProfile on resource: instance profile hotosm-production-cluster_13539192016233945975 because no identity-based policy allows the iam:GetInstanceProfile action (aws-error-code=AccessDenied, aws-operation-name=GetInstanceProfile, aws-request-id=6ebd2441-6249-4973-a9cc-52151f00d8f3, aws-service-name=IAM, aws-status-code=403) (instance-profile=hotosm-production-cluster_13539192016233945975)"}
```
