### PR TITLE
Add standalone GPU nodepool and temp remove spot requests

### DIFF
--- a/apps/karpenter/gpu-ec2nodeclass.yaml
+++ b/apps/karpenter/gpu-ec2nodeclass.yaml
@@ -1,0 +1,35 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: autoscale-gpu
+spec:
+  amiFamily: AL2
+
+  role: KarpenterNodeRole-hotosm-production-cluster
+
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: hotosm-production-cluster
+
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: hotosm-production-cluster
+
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        deleteOnTermination: true
+
+  tags:
+    Name: karpenter-autoscale-gpu
+    karpenter.sh/discovery: hotosm-production-cluster
+
+  # The machine image used as the node base OS
+  amiSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: hotosm-production-cluster
+    # AMD64 Ubuntu Noble 1.34 for eks (us-east-1)
+    - id: ami-0b80d15d9f1903b69
+    

--- a/apps/karpenter/gpu-nodepool.yaml
+++ b/apps/karpenter/gpu-nodepool.yaml
@@ -14,11 +14,11 @@ spec:
   template:
     metadata:
       labels:
-        nodegroup: autoscale
+        nodegroup: autoscale-gpu
         node-type: gpu
     spec:
       nodeClassRef:
-        name: autoscale
+        name: autoscale-gpu
         group: karpenter.k8s.aws
         kind: EC2NodeClass
 
@@ -27,10 +27,6 @@ spec:
           value: "true"
           effect: NoSchedule
 
-        - key: spot
-          value: "true"
-          effect: PreferNoSchedule
-
       requirements:
         - key: karpenter.k8s.aws/instance-family
           operator: In
@@ -38,7 +34,7 @@ spec:
 
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot", "on-demand"]
+          values: ["spot"]
 
         - key: kubernetes.io/arch
           operator: In
@@ -47,7 +43,7 @@ spec:
         # Prevent unexpectedly huge GPU nodes
         - key: karpenter.k8s.aws/instance-cpu
           operator: Lt
-          values: ["32"]
+          values: ["8"]
 
   limits:
     cpu: "200"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)


## Describe this PR

I started to go through disabling spot for gpu nodes, but realized we also need a GPU optimized AMI as well. Per the note in the [spec nodeselectorterms](https://karpenter.sh/docs/concepts/nodeclasses/#specamiselectorterms), karpenter only looks at architecture to determine optimal nodes, so a separate class is recommended for GPUs. 

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?