### PR TITLE
Add root redirect to Hanko ingress

### DIFF
--- a/apps/hanko/ingress.yaml
+++ b/apps/hanko/ingress.yaml
@@ -121,3 +121,12 @@ spec:
                 name: hanko-public
                 port:
                   name: http
+          # Root redirect to /app (handled by frontend nginx)
+          # In Hanko ingress because it doesn't use rewrite-target (nginx-ingress bug #8208)
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: login-prod-frontend
+                port:
+                  number: 80


### PR DESCRIPTION
Move / redirect from login chart to Hanko ingress (nginx-ingress bug #8208 with rewrite-target)