### PR TITLE
Fix ref to sealed secret

### DIFF
--- a/apps/mlflow/helm/values.yaml
+++ b/apps/mlflow/helm/values.yaml
@@ -60,9 +60,11 @@ artifactRoot:
 auth:
   enabled: true
   adminUsername: admin
-  existingSecret:
-    name: "mlflow-admin-password"
-    keyOfAdminPassword: "adminPassword"
+  adminPassword:
+    valueFrom:
+      secretKeyRef:
+        name: "mlflow-admin-password"
+        key: "adminPassword"
 ldapAuth:
   enabled: false
 ingress:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #107 

## Describe this PR

Got an error in argo: 
```
ComparisonError: Failed to load target state: failed to generate manifest for source 1 of 3: rpc error: code = Unknown desc = failed to execute helm template command: failed to get command args to log: `helm template . --name-template mlflow --namespace mlflow --kube-version 1.33 --values <path to cached source>/apps/mlflow/helm/values.yaml <api versions removed> --include-crds` failed exit status 1: Error: values don't meet the specifications of the schema(s) in the following chart(s):
mlflow:
- auth: Additional property existingSecret is not allowed
```

So I realized I set up the secret wrong. Docs on bitnami were not clear but this [looks like a way for secrets to be called](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret) in k8s. Let me know if this is incorrect! 
