### PR TITLE
Add back target for zenml secrets injection patch

### DIFF
--- a/apps/zenml/kustomization.yaml
+++ b/apps/zenml/kustomization.yaml
@@ -3,7 +3,11 @@ resources:
 
 patches:
   # Inject secret env vars into main zenml container
-  - path: deployment-secret-env-patch.yaml
+  - target:
+      kind: Deployment
+      name: zenml
+      namespace: zenml
+    path: deployment-secret-env-patch.yaml
 
   # Add custom labels
   - target:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #112 

## Describe this PR

Got an error on argocd:
```
Failed to load target state: failed to generate manifest for source 3 of 3: rpc error: code = Unknown desc = Manifest generation error (cached): `kustomize build <path to cached source>/apps/zenml` failed exit status 1: Error: no resource matches strategic merge patch "Deployment.v1.apps/zenml.zenml": no matches for Id Deployment.v1.apps/zenml.zenml; failed to find unique target for patch Deployment.v1.apps/zenml.zenml
```

So I think we need to be specific about the patch target. This change adds back the target from prior commit.  

