### PR TITLE
Disable eoapi bundled metrics-server (replace with cluster-wide)

### DIFF
--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -1,3 +1,7 @@
+# We install this cluster-wide instead via Argo
+metrics-server:
+  enabled: false
+
 prometheus-adapter:
   prometheus:
     url: http://eoapi-support-prometheus-server.eoapi-support.svc.cluster.local


### PR DESCRIPTION
- The eoapi-support bundled metrics-server is broken anyway, as it uses a deprecated bitnami chart.
- Once we upgrade eoapi, this would be fixed by merging eoapi+eoapi-support, but using bitnami legacy.
- But we want a cluster-wide metrics-server anyway, so will do that instead.