### PR TITLE
Disable eoapi metrics-server, run cluster wide

### DIFF
--- a/apps/metrics-server.yaml
+++ b/apps/metrics-server.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/metrics-server
+      chart: metrics-server
+      targetRevision: 3.13.0
+      helm:
+        releaseName: metrics-server
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true

--- a/kubernetes/helm/eoapi-support-values.yaml
+++ b/kubernetes/helm/eoapi-support-values.yaml
@@ -1,6 +1,10 @@
-# We install this cluster-wide instead via Argo
+# We install metrics-server cluster-wide via ArgoCD instead.
+# This chart doesn't support disabling it, so prevent conflicts
+# by stopping it from registering the API service and scale to 0.
 metrics-server:
-  enabled: false
+  apiService:
+    create: false
+  replicas: 0
 
 prometheus-adapter:
   prometheus:


### PR DESCRIPTION
Replaces https://github.com/hotosm/k8s-infra/pull/125

Also deploys cluster-wide metrics-server.