### PR TITLE
Contractor access to ArgoCD UI

### DIFF
--- a/apps/argocd/README.md
+++ b/apps/argocd/README.md
@@ -1,0 +1,35 @@
+# ArgoCD
+
+Installs ArgoCD from the upstream `cluster-install` manifests
+and layers on the following customisations:
+
+- **Tailscale Service exposure** (`argocd-server-svc-patch.yaml`)
+  - annotates the `argocd-server` Service with
+  `tailscale.com/expose: "true"` and `tailscale.com/hostname: argocd`,
+  so anyone in the tailnet can reach the UI at
+  `http://argocd` (MagicDNS) without `kubectl port-forward`.
+- **`server.insecure: "true"`** (`argocd-cmd-params-cm-patch.yaml`)
+  - the Tailscale proxy doesn't terminate TLS, so `argocd-server`
+  runs plain HTTP (the tailnet itself is WireGuard-encrypted).
+- **Read-only `contractor` account** (`argocd-cm-patch.yaml` +
+  `argocd-rbac-cm-patch.yaml`) - local account bound to the
+  built-in `role:readonly`, for contractors to view sync /
+  deploy status without being able to modify anything.
+
+## Setting the contractor password
+
+ArgoCD does not let you declare a password in a ConfigMap.
+After the account is created, an admin must set it via the
+CLI:
+
+```bash
+# Log in as admin
+argocd login argocd --username admin --plaintext
+
+# Set the contractor password (you will be prompted twice)
+argocd account update-password \
+  --account contractor \
+  --current-password '<admin-password>'
+```
+
+Share the resulting password with the contractor.

--- a/apps/argocd/argocd-cm-patch.yaml
+++ b/apps/argocd/argocd-cm-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  # Read-only local account for contractors to view deploy
+  # status. Read README for setting password.
+  accounts.contractor: login
+  accounts.contractor.enabled: "true"

--- a/apps/argocd/argocd-cmd-params-cm-patch.yaml
+++ b/apps/argocd/argocd-cmd-params-cm-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+data:
+  # Disable Argo TLS so we can terminate with Tailscale instead
+  server.insecure: "true"

--- a/apps/argocd/argocd-rbac-cm-patch.yaml
+++ b/apps/argocd/argocd-rbac-cm-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+data:
+  policy.csv: |
+    g, contractor, role:readonly

--- a/apps/argocd/argocd-server-svc-patch.yaml
+++ b/apps/argocd/argocd-server-svc-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: argocd

--- a/apps/argocd/kustomization.yaml
+++ b/apps/argocd/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 namespace: argocd
 resources:
 - github.com/argoproj/argo-cd//manifests/cluster-install?ref=v3.1.0
+patches:
+- path: argocd-cm-patch.yaml
+- path: argocd-cmd-params-cm-patch.yaml
+- path: argocd-rbac-cm-patch.yaml
+- path: argocd-server-svc-patch.yaml

--- a/apps/cluster-rbac/README.md
+++ b/apps/cluster-rbac/README.md
@@ -1,8 +1,10 @@
 # Cluster RBAC
 
 - Simple roles for users in the cluster:
-  - Admin is the default
-  - Role for read-only and for contractor (namespace scoped).
+  - Admin is the default.
+  - `viewers` group: cluster-wide read-only (`view` ClusterRole).
+  - `contractor` group: cluster-wide read-only (`view` ClusterRole)
+    plus `edit` on the namespaces listed in `values.yaml`.
 - This is utilised by Tailscale when accessing the cluster,
-  meaning tailscale users marked as either 'read-only' or
+  meaning tailscale users marked as either 'viewers' or
   'contractor' will be matched with the relevant RBAC role.

--- a/apps/cluster-rbac/templates/contractor-roles.yaml
+++ b/apps/cluster-rbac/templates/contractor-roles.yaml
@@ -1,3 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: contractor-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: Group
+  name: contractor
+  apiGroup: rbac.authorization.k8s.io
 {{- range .Values.contractorNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Added read-only permission to all namespaces for contractor accounts.
- Exposes ArgoCD UI via Tailscale, instead of needing to port-forward every time (anyone on the tailnet can access).
- Creates a 'contractor' account in ArgoCD, with permission to view deployments but not modify them.

When deploying:                                                                                                                                                                                        
- [ ] Tailscale HTTPS certs must be enabled in the tailnet admin console (Settings → DNS → Enable HTTPS).                                
- [ ] Set the contractor password via instructions in attached readme.

## Checklist before requesting a review

- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?