### PR TITLE
switch : amifamily al2023 for gpu 

### DIFF
--- a/apps/karpenter/gpu-ec2nodeclass.yaml
+++ b/apps/karpenter/gpu-ec2nodeclass.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Karpenter v1 no longer has a native Ubuntu AMI family. Use the AL2
   # bootstrap path with the pinned Ubuntu GPU AMI.
-  amiFamily: AL2
+  amiFamily: AL2023
 
   role: KarpenterNodeRole-hotosm-production-cluster
 
@@ -29,6 +29,6 @@ spec:
     Name: karpenter-autoscale-gpu
     karpenter.sh/discovery: hotosm-production-cluster
 
-  # AMD64 Ubuntu Noble 1.34 GPU image for EKS (us-east-1).
+  # AL2023 x86_64 NVIDIA GPU AMI for EKS 1.33 (us-east-1).
   amiSelectorTerms:
     - id: ami-0b80d15d9f1903b69


### PR DESCRIPTION
## What does this PR do ? 
- switches amifamily to [al2023](https://karpenter.sh/v1.0/concepts/nodeclasses/#al2023) because of following error at al2 

```
!!!!!!!!!! ERROR: bootstrap.sh has been removed from AL2023-based EKS AMIs.
  !!!!!!!!!! EKS nodes are now initialized by nodeadm.
  !!!!!!!!!!     https://awslabs.github.io/amazon-eks-ami/nodeadm/

  FAILED: Failed to start nodeadm-config.service - EKS Nodeadm Config.
  ```