### PR TITLE
feat : add fair-inference-nodepool

### DIFF
--- a/apps/karpenter/cpu-nodepool-fair-inference.yaml
+++ b/apps/karpenter/cpu-nodepool-fair-inference.yaml
@@ -1,0 +1,51 @@
+# CPU NodePool for fAIr batch inference
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: cpu-autoscale-fair-inference
+spec:
+  template:
+    metadata:
+      labels:
+        nodegroup: autoscale
+        node-type: cpu
+        fair-k8s/inference: "true"
+    spec:
+      nodeClassRef:
+        name: autoscale
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+
+      taints:
+        - key: fair-k8s/inference
+          value: "true"
+          effect: NoSchedule
+
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["c6a", "c6i", "c7a", "c7i", "m6a", "m6i", "m7a", "m7i"]
+
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: In
+          values: ["4", "8"]
+
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["5"]
+
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+
+  limits:
+    cpu: "16"
+    memory: 64Gi
+
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s


### PR DESCRIPTION
## What does this PR do ? 
- It adds fAIr batch inference node pool for cpu based images , because inference don't require GPU  , I think it would save resources to run inference on CPU based instances and we should only use GPU for training 