### PR TITLE
Migrate karpenter to its own namespace

### DIFF
--- a/apps/karpenter.yaml
+++ b/apps/karpenter.yaml
@@ -26,7 +26,7 @@ spec:
       path: apps/karpenter
   destination:
     server: https://kubernetes.default.svc
-    namespace: kube-system
+    namespace: karpenter
   syncPolicy:
     automated:
       selfHeal: true

--- a/apps/karpenter/nvidia-device-plugin.yaml
+++ b/apps/karpenter/nvidia-device-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-device-plugin
-  namespace: kube-system
+  namespace: karpenter
   labels:
     app.kubernetes.io/name: nvidia-device-plugin
 spec:

--- a/terraform/karpenter.tf
+++ b/terraform/karpenter.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "karpenter_controller_assume_role" {
     condition {
       test     = "StringEquals"
       variable = "${replace(aws_iam_openid_connect_provider.cluster_oidc.url, "https://", "")}:sub"
-      values   = ["system:serviceaccount:kube-system:karpenter"]
+      values   = ["system:serviceaccount:karpenter:karpenter"]
     }
   }
 }


### PR DESCRIPTION
## Describe this PR

According to Ysh, moving karpenter to its own namespace will reduce the "blast radius" of any faulty changes made. 

We will need to push the terraform changes once merged. 
