### PR TITLE
Remove cluster-autoscaler, fix core nodegroup at 5, use karptenter instead

### DIFF
--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -75,60 +75,6 @@ resource "aws_iam_openid_connect_provider" "cluster_oidc" {
   url             = data.tls_certificate.cluster_oidc_certificate.url
 }
 
-# https://github.com/kubernetes/autoscaler/blob/87a67e3aa0c831695f60408605d71f8e6ecdf90a/cluster-autoscaler/cloudprovider/aws/README.md?plain=1#L20
-data "aws_iam_policy_document" "cluster_autoscaler" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:DescribeTags",
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeScalingActivities",
-      "ec2:DescribeImages",
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeLaunchTemplateVersions",
-      "ec2:GetInstanceTypesFromInstanceRequirements",
-      "eks:DescribeNodegroup"
-    ]
-
-    resources = ["*"]
-  }
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup"
-    ]
-
-    resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${aws_eks_cluster.cluster.id}"
-      values   = ["owned"]
-    }
-  }
-}
-
-resource "aws_iam_role" "cluster_autoscaler" {
-  name                 = "${local.cluster_prefix}-cluster-autoscaler"
-  assume_role_policy   = data.aws_iam_policy_document.assume_role_with_oidc.json
-  permissions_boundary = var.permissions_boundary
-}
-
-resource "aws_iam_policy" "cluster_autoscaler" {
-  name   = "${local.cluster_prefix}-ClusterAutoscalerPolicy"
-  policy = data.aws_iam_policy_document.cluster_autoscaler.json
-}
-
-resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
-  role       = aws_iam_role.cluster_autoscaler.name
-  policy_arn = aws_iam_policy.cluster_autoscaler.arn
-}
-
 resource "aws_eks_access_entry" "admin_access" {
   count = length(local.cluster_admins)
 

--- a/terraform/helm-repos.tf
+++ b/terraform/helm-repos.tf
@@ -11,37 +11,6 @@ provider "helm" {
   }
 }
 
-resource "helm_release" "autoscaler" {
-  name             = "cluster-autoscaler"
-  repository       = "https://kubernetes.github.io/autoscaler"
-  chart            = "cluster-autoscaler"
-  version          = var.cluster_autoscaler_version
-  namespace        = "cluster-autoscaler"
-  create_namespace = true
-
-  set {
-    name  = "autoDiscovery.clusterName"
-    value = aws_eks_cluster.cluster.name
-  }
-
-  set {
-    name  = "awsRegion"
-    value = var.region
-  }
-
-  set {
-    # Double escaping needed as otherwise . is inteprerted as nesting
-    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = aws_iam_role.cluster_autoscaler.arn
-  }
-
-  wait = true
-
-  depends_on = [
-    aws_eks_cluster.cluster
-  ]
-}
-
 resource "helm_release" "ingress" {
   name             = "ingress"
   repository       = "https://kubernetes.github.io/ingress-nginx"

--- a/terraform/nodes.tf
+++ b/terraform/nodes.tf
@@ -94,15 +94,11 @@ resource "aws_eks_node_group" "core_nodes" {
   disk_size = 80
 
   scaling_config {
-    desired_size = 1
-    max_size     = var.max_instances
-    min_size     = 0
+    desired_size = var.core_nodegroup_size
+    max_size     = var.core_nodegroup_size
+    min_size     = var.core_nodegroup_size
   }
 
-  lifecycle {
-    # Allow cluster-autoscaler to change the size of nodepool without messing up terraform
-    ignore_changes = [scaling_config[0].desired_size]
-  }
   update_config {
     max_unavailable = 1
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,11 +75,13 @@ variable "capacity_type" {
   }
 }
 
-variable "max_instances" {
-  default     = 10
+variable "core_nodegroup_size" {
+  default     = 5
   type        = number
   description = <<-EOT
-  Maximum number of instances the autoscaler will scale the cluster up to.
+  Fixed size of the managed "core" nodegroup (min = max = desired).
+  Karpenter provisions any additional capacity above this baseline via
+  its own NodePools.
   EOT
 }
 
@@ -121,13 +123,6 @@ variable "ebs_driver_version" {
   description = <<-EOT
   EBS CSI Driver version
   cmd: aws eks describe-addon-versions --kubernetes-version <kubernetes-version>
-  EOT
-}
-
-variable "cluster_autoscaler_version" {
-  default     = "9.46.6"
-  description = <<-EOT
-  Version of cluster autoscaler helm chart to install.
   EOT
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to https://github.com/hotosm/k8s-infra/issues/4

## Describe this PR

- Cluster autoscaler is redundant now, due to Karptenter.
- We have 7 nodes, which is probably a bit too many - switching to 5 in core group + extra capacity by Karpenter as needed.