### PR TITLE
Register vpc-cni, coredns, kube-proxy as EKS managed add-ons

### DIFF
--- a/terraform/addons.tf
+++ b/terraform/addons.tf
@@ -35,3 +35,65 @@ resource "aws_eks_addon" "ebs_provisioner" {
     aws_iam_role_policy_attachment.ebs_provisioner
   ]
 }
+
+# Setup the Amazon VPC CNI addon (pod networking).
+# Adopted from the self-managed default with `resolve_conflicts_on_create = OVERWRITE`.
+data "aws_iam_policy_document" "vpc_cni_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.cluster_oidc.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.cluster_oidc.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-node"]
+    }
+  }
+}
+
+resource "aws_iam_role" "vpc_cni" {
+  name                 = "${local.cluster_prefix}-eks-vpc-cni"
+  assume_role_policy   = data.aws_iam_policy_document.vpc_cni_assume_role.json
+  permissions_boundary = var.permissions_boundary
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_cni" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.vpc_cni.name
+}
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "vpc-cni"
+  addon_version               = var.vpc_cni_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  service_account_role_arn    = aws_iam_role.vpc_cni.arn
+  depends_on = [
+    aws_iam_role_policy_attachment.vpc_cni
+  ]
+}
+
+# CoreDNS managed add-on (cluster DNS).
+resource "aws_eks_addon" "coredns" {
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "coredns"
+  addon_version               = var.coredns_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+}
+
+# kube-proxy managed add-on (per-node service proxy).
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "kube-proxy"
+  addon_version               = var.kube_proxy_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+}

--- a/terraform/helm-repos.tf
+++ b/terraform/helm-repos.tf
@@ -4,7 +4,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority[0].data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
+      api_version = "client.authentication.k8s.io/v1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.cluster.name]
     }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -126,6 +126,33 @@ variable "ebs_driver_version" {
   EOT
 }
 
+variable "vpc_cni_version" {
+  type        = string
+  default     = "v1.22.2-eksbuild.1"
+  description = <<-EOT
+  Amazon VPC CNI add-on version. Default is compatible with Kubernetes 1.33.
+  cmd: aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version <kubernetes-version>
+  EOT
+}
+
+variable "coredns_version" {
+  type        = string
+  default     = "v1.12.4-eksbuild.18"
+  description = <<-EOT
+  CoreDNS add-on version. Default is compatible with Kubernetes 1.33.
+  cmd: aws eks describe-addon-versions --addon-name coredns --kubernetes-version <kubernetes-version>
+  EOT
+}
+
+variable "kube_proxy_version" {
+  type        = string
+  default     = "v1.33.10-eksbuild.13"
+  description = <<-EOT
+  kube-proxy add-on version. Default is compatible with Kubernetes 1.33.
+  cmd: aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version <kubernetes-version>
+  EOT
+}
+
 variable "nginx_ingress_version" {
   default     = "4.12.1"
   description = <<-EOT


### PR DESCRIPTION
- Prep for #153 by adding core Kubernetes components to OpenTofu, so they can be upgraded as needed.
- EKS automatically adds these components when the cluster is first init.

Useful commands:

`aws eks describe-addon-versions --kubernetes-version 1.34 --addon-name aws-ebs-csi-driver --region us-east-1`

and

`aws eks list-insights --cluster-name hotosm-production-cluster --region us-east-1`

and 

`aws --profile admin --region us-east-1 eks list-addons --cluster-name hotosm-production-cluster`