### PR TITLE
fix(tm-sandbox): remove dead cluster-issuer keys, bump dashboard image for cert-manager fix

### DIFF
--- a/apps/tm-sandbox/helm/values.yaml
+++ b/apps/tm-sandbox/helm/values.yaml
@@ -1,11 +1,9 @@
 environment: production
 serviceType: ClusterIP
 namespace: tm-sandbox
-createClusterIssuer: true
 adminEmail: admin@sandbox.hotosm.org
 
 ssl_certificate:
-  create_cluster_issuer: false
   create_cert: true
 
 service_account:

--- a/apps/tm-sandbox/helm/values.yaml
+++ b/apps/tm-sandbox/helm/values.yaml
@@ -49,7 +49,7 @@ db:
 dashboard:
   image:
     name: ghcr.io/hotosm/osm-sandbox-dashboard/dashboard
-    tag: e81440a1426a5b9c5173cddc9c57a6129f41bc45
+    tag: c53c30ab21e05f301d7b10186023efb7fd4d1b2c
   enabled: true
   ingressDomain: sandbox.hotosm.org
   persistenceDisk:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix


## Related Issue

Follow-up to [hotosm/osm-sandbox-dashboard#5](https://github.com/hotosm/osm-sandbox-dashboard/pull/5)

## Describe this PR

- Remove dead `createClusterIssuer` / `ssl_certificate.create_cluster_issuer` keys from `apps/tm-sandbox/helm/values.yaml` 
- Bump `dashboard.image.tag` to `c53c30ab21e05f301d7b10186023efb7fd4d1b2c`, which contains the cert-manager issuer fix (letsencrypt-prod-issuer to letsencrypt-prod).

## Review Guide

Once merged, ArgoCD auto-syncs `tm-sandbox` to the new image. Existing `naxa`/`osm` boxes might need a manual `helm upgrade` after this rolls out.