### PR TITLE
fix(tm-sandbox): set redeploy strategy to Recreate, bump dashboard image

### DIFF
--- a/apps/tm-sandbox/helm/values.yaml
+++ b/apps/tm-sandbox/helm/values.yaml
@@ -50,6 +50,8 @@ dashboard:
   image:
     name: ghcr.io/hotosm/osm-sandbox-dashboard/dashboard
     tag: c53c30ab21e05f301d7b10186023efb7fd4d1b2c
+  strategy:
+    type: Recreate
   enabled: true
   ingressDomain: sandbox.hotosm.org
   persistenceDisk:

--- a/apps/tm-sandbox/helm/values.yaml
+++ b/apps/tm-sandbox/helm/values.yaml
@@ -49,7 +49,7 @@ db:
 dashboard:
   image:
     name: ghcr.io/hotosm/osm-sandbox-dashboard/dashboard
-    tag: c53c30ab21e05f301d7b10186023efb7fd4d1b2c
+    tag: 94c54832cb5a806043aa4459970406ff99a383eb
   strategy:
     type: Recreate
   enabled: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Issue

Follow-up to [hotosm/osm-sandbox-dashboard#6](https://github.com/hotosm/osm-sandbox-dashboard/pull/6)

## Describe this PR

- Set `dashboard.strategy.type: Recreate` - fixes a RollingUpdate deadlock on the dashboard's RWO EBS volume.
- Bump `dashboard.image.tag` to `94c54832cb5a806043aa4459970406ff99a383eb` - loosens DB probe timeouts to prevent crash loops.
