### PR TITLE
fix(zenml): add missing orchestrator-role manifest to production depl…

### DIFF
--- a/apps/zenml-prod/orchestrator-role.yaml
+++ b/apps/zenml-prod/orchestrator-role.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zenml-service-connector
+  namespace: zenml-pipelines
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zenml-pod-account
+  namespace: zenml-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: zenml-pipelines
+  name: zenml-orchestrator-service-role
+rules:
+  # Core API Group: 
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  
+  # Batch API Group: ZenML runs steps as Jobs and scheduled pipelines as CronJobs
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "create", "patch"]
+
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["create", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: zenml-pipelines # Replace with your target namespace
+  name: zenml-orchestrator-pod-role
+rules:
+  # Core API Group: Manage Pods, read step logs, and use ServiceAccounts
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  
+  # Batch API Group: ZenML runs steps as Jobs and scheduled pipelines as CronJobs
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+    
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zenml-service-binding
+  namespace: zenml-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: zenml-orchestrator-service-role
+subjects:
+  - kind: ServiceAccount
+    name: zenml-service-connector
+    namespace: zenml-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zenml-pod-binding
+  namespace: zenml-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: zenml-orchestrator-pod-role
+subjects:
+  - kind: ServiceAccount
+    name: zenml-pod-account
+    namespace: zenml-pipelines


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

## Describe this PR

A brief description of how this solves the issue.
Added missing orchestrator-role manifest to production deployment for zenml-prod

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?