### PR TITLE
feat: secure kubeview behind tailscale loadbalancer

### DIFF
--- a/apps/kubeview/service.yaml
+++ b/apps/kubeview/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubeview
+  namespace: kubeview 
+  annotations:
+    tailscale.com/hostname: "kubeview"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: "kubeview" 
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

## Describe this PR

### Overview
This PR secures `kubeview` behind Tailscale. This drops the need for manual `kubectl port-forward` commands by bridging the dashboard directly to our private Tailnet.

### Key Technical Updates
* **Zero-Trust Access:** Added a `service.yaml` in `apps/kubeview` using `type: LoadBalancer` and `loadBalancerClass: tailscale`.
* **Traffic Routing:** Targets the existing deployment in the `kubeview` namespace and maps Tailnet traffic to `containerPort: 8000`.
* **MagicDNS:** Applies the `tailscale.com/hostname` annotation so the operator automatically registers the hostname.

### Access & Validation Instructions
Once merged and synced by ArgoCD, the Tailscale Operator will automatically provision the proxy pod. To verify:

1. Ensure you are connected to the Tailscale network.
2. Open your browser and navigate to: `http://kubeview`

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?