### PR TITLE
chore(mlflow-prod): disable database migration post-initial deployment

### DIFF
--- a/apps/mlflow-prod/helm/values.yaml
+++ b/apps/mlflow-prod/helm/values.yaml
@@ -7,7 +7,7 @@ image:
 
 # Target the NEW CloudNativePG cluster created for mlflow-prod
 backendStore:
-  databaseMigration: true # Remember to set to true on first deployment
+  databaseMigration: false # Disabled post-initial deployment
   databaseConnectionCheck: true
   postgres:
     enabled: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

## Describe this PR

Just a quick housekeeping PR for our MLflow prod deployment.

Since we successfully got MLflow deployed and the initial database tables are already fully built in our Postgres cluster, I'm flipping the databaseMigration flag to false in the Helm values.

This just stops the init container from running unnecessary schema checks every time a pod scales or restarts, which should speed up our boot times moving forward.

Everything is tested and running green on my end. Let me know if you need anything else before merging!

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Contributing Guide: <https://docs.hotosm.org/become-a-contributor/>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?